### PR TITLE
Update documentation for file extension consistency

### DIFF
--- a/COOLIFY-ENVIRONMENT.md
+++ b/COOLIFY-ENVIRONMENT.md
@@ -102,13 +102,13 @@ This guide provides detailed instructions for configuring environment variables 
 2. **Branch**: `prep-for-coolify`
 3. **Build Context**: Root directory
 4. **Dockerfile Path**: `./Dockerfile`
-5. **Docker Compose Path**: `./docker-compose.yml`
+5. **Docker Compose Path**: `./docker-compose.yaml`
 
 ### 3. Build Configuration
 
 1. **Build Command**: Not required (Docker handles build)
 2. **Install Command**: Not required
-3. **Start Command**: Defined in docker-compose.yml
+3. **Start Command**: Defined in docker-compose.yaml
 
 ### 4. Volume Configuration
 
@@ -140,7 +140,7 @@ Since this application doesn't serve web traffic:
 
 ### 6. Health Check Configuration
 
-Health checks are defined in docker-compose.yml:
+Health checks are defined in docker-compose.yaml:
 
 ```yaml
 healthcheck:

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -101,7 +101,7 @@ docker volume inspect declue-spotify-check_app_data
 
 For production deployment, consider:
 
-1. **Resource Limits**: Add memory and CPU limits to docker-compose.yml
+1. **Resource Limits**: Add memory and CPU limits to docker-compose.yaml
 2. **Restart Policies**: Already configured with `unless-stopped`
 3. **Monitoring**: Use container monitoring tools
 4. **Backup**: Regular backup of the `app_data` volume


### PR DESCRIPTION
Change all instances of `.yml` to `.yaml` in the documentation to ensure consistency in file extensions.